### PR TITLE
feat: add uwufetch & refactor version getting code

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -3,6 +3,7 @@
     "fetchfetch",
     "fastfetch",
     "neofetch",
-    "onefetch"
+    "onefetch",
+    "uwufetch"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ $ fetchfetch
 * [Fastfetch][fastfetch]
 * [Neofetch][neofetch]
 * [onefetch][onefetch]
+* [UwUfetch][uwufetch]
 
 [fastfetch]: https://github.com/fastfetch-cli/fastfetch
 [neofetch]: https://github.com/dylanaraps/neofetch
-[onefetch]: https://github.com/o2sh/onefetch/
+[onefetch]: https://github.com/o2sh/onefetch
+[uwufetch]: https://github.com/ad-oliviero/uwufetch

--- a/stats.c
+++ b/stats.c
@@ -61,37 +61,46 @@ bool is_boundary(char c) {
 /**
  * Splits outputs in the format `"Appname x.y.z\n"` into `"x.y.z"`.
  */
-const char* extract_named_version(const char *version_info) {
+const char* extract_named_version(const char *version_info, const char *prefix) {
 	int start;
 	int end;
 	int len;
+	int prefix_len = strlen(prefix);
 
 	if (version_info == app_version_fallback) {
 		return version_info;
 	}
 
 	len = strlen(version_info);
-	for (start = 0; version_info[start] != ' ' && start < len; start++);
-	for (end = start + 1; end < len && !is_boundary(version_info[end]); end++);
-	return strndup(version_info + start + 1, end - start - 1);
+	for (start = 0; version_info[start] != '\0' && strncmp(version_info + start, prefix, prefix_len) != 0; start++);
+	if (start >= len) return NULL; // Prefix not found
+	start += prefix_len;
+	for (end = start; end < len && !is_boundary(version_info[end]); end++);
+	return strndup(version_info + start, end - start);
 }
 
 const char* fastfetch() {
 	// NOTE Version in the format "fastfetch x.x.x (ARCH)"
 	char *out = app_version("fastfetch --version");
-	return extract_named_version(out);
+	return extract_named_version(out, "fastfetch ");
 }
 
 const char* neofetch() {
 	// NOTE Version in the format "Neofetch x.x.x"
 	char *out = app_version("neofetch --version");
-	return extract_named_version(out);
+	return extract_named_version(out, "Neofetch ");
 }
 
 const char* onefetch() {
 	// NOTE Version in the format "onefetch x.x.x"
 	char *out = app_version("onefetch --version");
-	return extract_named_version(out);
+	return extract_named_version(out, "onefetch ");
+}
+
+char* uwufetch() {
+	// NOTE Version in the format "UwUfetch version x.x"
+	char *out = app_version("uwufetch --version");
+	return extract_named_version(out, "UwUfetch version ");
 }
 
 FetchStat* get_stats() {
@@ -102,5 +111,7 @@ FetchStat* get_stats() {
 	stats[1].version = neofetch();
 	stats[2].label = "onefetch";
 	stats[2].version = onefetch();
+	stats[3].label = "UwUfetch";
+	stats[3].version = uwufetch();
 	return stats;
 }

--- a/stats.h
+++ b/stats.h
@@ -36,7 +36,12 @@ const char* neofetch();
  */
 const char* onefetch();
 
-#define STATS_SIZE 3
+/**
+ * Gets UwUfetch version information.
+ */
+char* uwufetch();
+
+#define STATS_SIZE 4
 /**
  * Gets all stats.
  */


### PR DESCRIPTION
now ~errors like `sh: line 1: neofetch: command not found` will be suppressed and~ `extract_named_version` will be more flexible