### PR TITLE
Report fetchfetch's own version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-fetchfetch: art.o stats.o fetchfetch.c
-	$(CC) -o fetchfetch art.o stats.o fetchfetch.c
+fetchfetch: art.o args.o stats.o fetchfetch.c
+	$(CC) -o fetchfetch art.o args.o stats.o fetchfetch.c
+
+args.o: args.c args.h
+	$(CC) -c -o args.o args.c
 
 art.o: art.c art.h
 	$(CC) -c -o art.o art.c

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ fetchfetch: art.o stats.o fetchfetch.c
 art.o: art.c art.h
 	$(CC) -c -o art.o art.c
 
-stats.o: stats.c stats.h
+stats.o: stats.c stats.h version.h
 	$(CC) -c -o stats.o stats.c
 
 .PHONY: run

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-fetchfetch: art.o args.o stats.o fetchfetch.c
-	$(CC) -o fetchfetch art.o args.o stats.o fetchfetch.c
+fetchfetch: art.o args.o stats.o version.o fetchfetch.c
+	$(CC) -o fetchfetch art.o args.o stats.o version.o fetchfetch.c
 
 args.o: args.c args.h
 	$(CC) -c -o args.o args.c
@@ -7,8 +7,11 @@ args.o: args.c args.h
 art.o: art.c art.h
 	$(CC) -c -o art.o art.c
 
-stats.o: stats.c stats.h version.h
+stats.o: stats.c stats.h version.c version.h
 	$(CC) -c -o stats.o stats.c
+
+version.o: version.c version.h
+	$(CC) -c -o version.o version.c
 
 .PHONY: run
 run: fetchfetch

--- a/args.c
+++ b/args.c
@@ -22,8 +22,17 @@ bool print_version = false;
 
 void parse_args(int argc, char **argv) {
 	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
+		if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+			print_help = true;
+		} else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
 			print_version = true;
 		}
 	}
 }
+
+const char *help_message = 	"Usage: fetchfetch [OPTIONS...]\n"
+							"Fetch the stats of your *fetch tools\n"
+							"\n"
+							"Options:\n"
+							"  -h, --help     Print this message and exit\n"
+							"  -v, --version  Print the version and exit\n";

--- a/args.c
+++ b/args.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include "args.h"
 
+bool print_help = false;
 bool print_version = false;
 
 void parse_args(int argc, char **argv) {

--- a/args.c
+++ b/args.c
@@ -13,36 +13,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
 #include "args.h"
-#include "art.h"
-#include "stats.h"
-#include "version.h"
 
-int main(int argc, char *argv[]) {
-	FetchStat *stats;
-	parse_args(argc, argv);
+bool print_version = false;
 
-	if (print_version) {
-		printf("fetchfetch %s\n", FETCHFETCH_VERSION);
-		return 0;
-	}
-
-	stats = get_stats();
-	for (int line_index = 0; line_index < ART_HEIGHT || line_index < STATS_SIZE; line_index++) {
-		if (line_index < ART_HEIGHT) {
-			for (int col_index = 0; col_index < ART_WIDTH; col_index++) {
-				putchar(art[line_index][col_index]);
-			}
-		} else {
-			printf(ART_FILLER);
+void parse_args(int argc, char **argv) {
+	for (int i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
+			print_version = true;
 		}
-
-		// NOTE We skip a line because it looks a little better.
-		if (line_index != 0 && line_index <= STATS_SIZE) {
-			printf(" %s: %s", stats[line_index - 1].label, stats[line_index - 1].version);
-		}
-		printf("\n");
 	}
-	return 0;
 }

--- a/args.h
+++ b/args.h
@@ -1,0 +1,24 @@
+/*
+ * fetchfetch - Fetch the stats of your *fetch tools
+ * Copyright (C) 2025  Spenser Black
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef FETCH_FETCH_ARGS_H
+#define FETCH_FETCH_ARGS_H
+#include <stdbool.h>
+
+extern bool print_version;
+
+void parse_args(int argc, char **argv);
+
+#endif

--- a/args.h
+++ b/args.h
@@ -19,6 +19,7 @@
 
 extern bool print_help;
 extern bool print_version;
+extern const char *help_message;
 
 void parse_args(int argc, char **argv);
 

--- a/args.h
+++ b/args.h
@@ -17,6 +17,7 @@
 #define FETCH_FETCH_ARGS_H
 #include <stdbool.h>
 
+extern bool print_help;
 extern bool print_version;
 
 void parse_args(int argc, char **argv);

--- a/fetchfetch.c
+++ b/fetchfetch.c
@@ -23,6 +23,10 @@ int main(int argc, char *argv[]) {
 	FetchStat *stats;
 	parse_args(argc, argv);
 
+	if (print_help) {
+		printf("%s", help_message);
+		return 0;
+	}
 	if (print_version) {
 		printf("fetchfetch %s\n", version);
 		return 0;

--- a/stats.c
+++ b/stats.c
@@ -115,7 +115,7 @@ FetchStat* get_stats() {
 	stats[0].label = "Fastfetch";
 	stats[0].version = fastfetch();
 	stats[1].label = "fetchfetch";
-	stats[1].version = FETCHFETCH_VERSION;
+	stats[1].version = version;
 	stats[2].label = "Neofetch";
 	stats[2].version = neofetch();
 	stats[3].label = "onefetch";

--- a/stats.c
+++ b/stats.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include "stats.h"
+#include "version.h"
 
 char *app_version_fallback = "Not installed";
 
@@ -113,13 +114,15 @@ FetchStat* get_stats() {
 	FetchStat *stats = malloc(STATS_SIZE * sizeof(FetchStat));
 	stats[0].label = "Fastfetch";
 	stats[0].version = fastfetch();
-	stats[1].label = "Neofetch";
-	stats[1].version = neofetch();
-	stats[2].label = "onefetch";
-	stats[2].version = onefetch();
-	stats[3].label = "pfetch";
-	stats[3].version = pfetch();
-	stats[4].label = "UwUfetch";
-	stats[4].version = uwufetch();
+	stats[1].label = "fetchfetch";
+	stats[1].version = FETCHFETCH_VERSION;
+	stats[2].label = "Neofetch";
+	stats[2].version = neofetch();
+	stats[3].label = "onefetch";
+	stats[3].version = onefetch();
+	stats[4].label = "pfetch";
+	stats[4].version = pfetch();
+	stats[5].label = "UwUfetch";
+	stats[5].version = uwufetch();
 	return stats;
 }

--- a/stats.h
+++ b/stats.h
@@ -17,8 +17,8 @@
 #define FETCH_FETCH_STATS_H
 
 typedef struct {
-	char *label;
-	char *version;
+	const char *label;
+	const char *version;
 } FetchStat;
 
 /**

--- a/version.c
+++ b/version.c
@@ -13,36 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <stdio.h>
-#include "args.h"
-#include "art.h"
-#include "stats.h"
 #include "version.h"
 
-int main(int argc, char *argv[]) {
-	FetchStat *stats;
-	parse_args(argc, argv);
-
-	if (print_version) {
-		printf("fetchfetch %s\n", version);
-		return 0;
-	}
-
-	stats = get_stats();
-	for (int line_index = 0; line_index < ART_HEIGHT || line_index < STATS_SIZE; line_index++) {
-		if (line_index < ART_HEIGHT) {
-			for (int col_index = 0; col_index < ART_WIDTH; col_index++) {
-				putchar(art[line_index][col_index]);
-			}
-		} else {
-			printf(ART_FILLER);
-		}
-
-		// NOTE We skip a line because it looks a little better.
-		if (line_index != 0 && line_index <= STATS_SIZE) {
-			printf(" %s: %s", stats[line_index - 1].label, stats[line_index - 1].version);
-		}
-		printf("\n");
-	}
-	return 0;
-}
+const char* version = "1.0.1";

--- a/version.h
+++ b/version.h
@@ -13,43 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef FETCH_FETCH_STATS_H
-#define FETCH_FETCH_STATS_H
+#ifndef FETCH_FETCH_VERSION_H
+#define FETCH_FETCH_VERSION_H
 
-typedef struct {
-	char *label;
-	char *version;
-} FetchStat;
-
-/**
- * Gets Fastfetch version information.
- */
-char* fastfetch();
-
-/**
- * Gets Neofetch version information.
- */
-char* neofetch();
-
-/**
- * Gets onefetch version information.
- */
-char* onefetch();
-
-/**
- * Gets pfetch version information.
- */
-char* pfetch();
-
-/**
- * Gets UwUfetch version information.
- */
-char* uwufetch();
-
-#define STATS_SIZE 6
-/**
- * Gets all stats.
- */
-FetchStat* get_stats();
+#define FETCHFETCH_VERSION "1.0.1"
 
 #endif

--- a/version.h
+++ b/version.h
@@ -16,6 +16,6 @@
 #ifndef FETCH_FETCH_VERSION_H
 #define FETCH_FETCH_VERSION_H
 
-#define FETCHFETCH_VERSION "1.0.1"
+extern const char *version;
 
 #endif


### PR DESCRIPTION
This both reports this tool's own version when getting run, and also adds basic CLI options so that the `--version` option could be added.