### PR TITLE
Allow users to right-pad labels

### DIFF
--- a/args.c
+++ b/args.c
@@ -14,25 +14,45 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "args.h"
 
+int right_pad = -1;
 bool print_help = false;
 bool print_version = false;
 
-void parse_args(int argc, char **argv) {
+bool parse_args(int argc, char **argv) {
+	char *arg;
+	char *end;
 	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+		arg = argv[i];
+		if (strcmp(arg, "-p") == 0 || strcmp(arg, "--pad") == 0) {
+			if (i == argc - 1) {
+				fprintf(stderr, "--pad takes 1 argument\n");
+				return false;
+			}
+			arg = argv[++i];
+			// NOTE We're ignoring overflows (the safety check isn't a priority for this tool).
+			right_pad = (int)strtol(arg, &end, 10);
+			if (end == arg || right_pad < 0) {
+				fprintf(stderr, "--pad expected a non-negative integer, got %s\n", arg);
+				return false;
+			}
+		} else if (strcmp(arg, "-h") == 0 || strcmp(arg, "--help") == 0) {
 			print_help = true;
-		} else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
+		} else if (strcmp(arg, "-v") == 0 || strcmp(arg, "--version") == 0) {
 			print_version = true;
 		}
 	}
+	return true;
 }
 
 const char *help_message = 	"Usage: fetchfetch [OPTIONS...]\n"
 							"Fetch the stats of your *fetch tools\n"
 							"\n"
 							"Options:\n"
+							"  -p, --pad N    Right-pad labels by N spaces to align values\n"
 							"  -h, --help     Print this message and exit\n"
 							"  -v, --version  Print the version and exit\n";

--- a/args.h
+++ b/args.h
@@ -17,10 +17,15 @@
 #define FETCH_FETCH_ARGS_H
 #include <stdbool.h>
 
+extern int right_pad;
 extern bool print_help;
 extern bool print_version;
 extern const char *help_message;
 
-void parse_args(int argc, char **argv);
+/**
+ * Parses arguments. Returns true if parsing succeeded (and execution should continue),
+ * false otherwise.
+ */
+bool parse_args(int argc, char **argv);
 
 #endif

--- a/fetchfetch.c
+++ b/fetchfetch.c
@@ -13,7 +13,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 #include "args.h"
 #include "art.h"
 #include "stats.h"
@@ -21,8 +23,14 @@
 
 int main(int argc, char *argv[]) {
 	FetchStat *stats;
-	parse_args(argc, argv);
+	bool ok = parse_args(argc, argv);
+	const char *label;
+	int label_len;
+	int pad_iter;
 
+	if (!ok) {
+		return 1;
+	}
 	if (print_help) {
 		printf("%s", help_message);
 		return 0;
@@ -44,7 +52,16 @@ int main(int argc, char *argv[]) {
 
 		// NOTE We skip a line because it looks a little better.
 		if (line_index != 0 && line_index <= STATS_SIZE) {
-			printf(" %s: %s", stats[line_index - 1].label, stats[line_index - 1].version);
+			printf(" %s:", label = stats[line_index - 1].label);
+			if (right_pad != -1) {
+				label_len = strlen(label);
+				for (pad_iter = label_len; pad_iter < right_pad; ++pad_iter) {
+					putchar(' ');
+				}
+			} else {
+				putchar(' ');
+			}
+			printf("%s", stats[line_index - 1].version);
 		}
 		printf("\n");
 	}


### PR DESCRIPTION
This allows users to align values by selecting how much they want to right-pad labels.

Resolves #12

```console
$ fetchfetch -p 15
 ______________________________________
|                                      | Fastfetch:      Not installed
|  >_                                  | fetchfetch:     1.0.1
|                                      | Neofetch:       7.1.0
|                                      | onefetch:       2.22.0
|                                      | pfetch:         Not installed
|                                      | UwUfetch:       Not installed
|                                      |
|                                      |
|______________________________________|
```

```console
$ fetchfetch -p 30
 ______________________________________
|                                      | Fastfetch:                     Not installed
|  >_                                  | fetchfetch:                    1.0.1
|                                      | Neofetch:                      7.1.0
|                                      | onefetch:                      2.22.0
|                                      | pfetch:                        Not installed
|                                      | UwUfetch:                      Not installed
|                                      |
|                                      |
|______________________________________|
```